### PR TITLE
Create pre-commit.yml

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,15 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1
+    


### PR DESCRIPTION
A simple hook for running pre-commit before PRs.

I want this to only run before someone merges stuff into `main`, so that they can develop at leisure (and probably because most people forget to do `pre-commit init`.