### PR TITLE
Add default .vscode file to avoid search explosion due to .snakemake/…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,10 @@
 ### Editors
 *~
 \#*\#
-**/.vscode
+**/.vscode/
+!/.vscode/
+.vscode/*
+!.vscode/settings.json
 .$*
 
 ### Byte-compiled files
@@ -39,4 +42,5 @@ tmp/
 results/
 report/
 
+### repo specific exceptions
 !modules/_example_module/**

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+    "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "**/node_modules/*/**": true,
+        "**/.hg/store/**": true,
+        "**/.snakemake/**": true
+    },
+    "search.exclude": {
+        "**/node_modules": true,
+        "**/bower_components": true,
+        "**/*.code-search": true,
+        "**/.snakemake": true
+    }
+}


### PR DESCRIPTION
Adding a default configuration so that VSCode (the most popular IDE in our team) does not search within .snakemake/, avoiding CPU spikes.

This should remain in place until https://github.com/snakemake/snakemake/issues/3033 is fixed or a more stable workaround is found.