### PR TITLE
Fix cds incompatibility

### DIFF
--- a/wrappers/atlite/cutout/environment.yaml
+++ b/wrappers/atlite/cutout/environment.yaml
@@ -4,3 +4,4 @@ channels:
   - nodefaults
 dependencies:
   - atlite = 0.2.14
+  - cdsapi = 0.7.2  # remove in next version


### PR DESCRIPTION
CDSAPI and `atlite` are not acting friendly for some reason. I've pinned the version until these tools are stable.