### PR TITLE
Fix demand_electricity integration issues

### DIFF
--- a/modules/demand_electricity/AUTHORS.md
+++ b/modules/demand_electricity/AUTHORS.md
@@ -5,6 +5,7 @@ This is the list of contributors to the 'demand_electricity' module for copyrigh
 - Tim Tröndle, ETH Zürich and IASS Potsdam <tim.troendle@usys.ethz.ch>
 - Bryn Pickering, University of Cambridge and ETH Zürich <bp325@cam.ac.uk>
 - Jann Launer, TU Delft <j.a.c.launer@tudelft.nl>
+- Ivan Ruiz Manuel, TU Delft <i.ruizmanuel@tudelft.nl>
 
 This does not necessarily list everyone who has contributed to the 'demand_electricity' module code or documentation.
 For a full contributor list, see:

--- a/modules/demand_electricity/README.md
+++ b/modules/demand_electricity/README.md
@@ -11,34 +11,44 @@ Here is a brief IO diagram of the module's operation.
 title: demand_electricity
 ---
 flowchart LR
-    D1[("`**Databases**
+    D1[("`**Automatic**
         raw-potentials/demand.csv
-        raw-load-data.csv
+        OPSD - time_series
         ...
     `")] --> |Download| M
-    C1[/"`**User input**
-        units.geojson
+    C1[/"`**User**
+        shapes_{resolution}.geojson
         ...
     `"/] --> M((demand_electricity))
-    M --> O1("
-        electricity-demand-national.csv
-        ")
-    M --> O2("
-        demand-electricity-ehighways.csv
-        ")
+    M --> O1("`**Timeseries**
+        {resolution}/{year}/demand_electricity.csv
+        `")
+    M --> O2("`**Plots**
+        {resolution}/{year}/plot_map.png
+        {resolution}/{year}/plot_timeseries.png
+        `")
 ```
 
 ### User
 
 - **resources/user/shapes_{resolution}.geojson**: a file with the shapes in the desired spatial resolution.
 
-### Output
+### Results
 
-- **results/electricity-demand-national.csv**: annual electricity demand per country.
-- **results/demand-electricity-{resolution}.csv**: annual electricity demand at subnational resolution.
+- **{resolution}/{year}/demand_electricity.csv**: annual electricity demand per region.
+- **{resolution}/{year}/plot_map.png**: map showing the distribution of annual demand.
+- **{resolution}/{year}/plot_timeseries.png**: annual demand timeseries and load duration curve.
 
 ## DAG
 
 Here is a brief example of the module's steps.
 
 ![DAG](rulegraph.png)
+
+## Citation
+
+Tröndle, T., & Pickering, B. (2021). Euro-Calliope Electricity Demand [Computer software]. <https://doi.org/10.5281/zenodo.3949793>
+
+## References
+
+- Open Power System Data (2020). Time series data package [Dataset]. <https://github.com/Open-Power-System-Data/time_series>

--- a/modules/demand_electricity/config/default.yaml
+++ b/modules/demand_electricity/config/default.yaml
@@ -2,7 +2,3 @@
 use_default_user_resources: true
 
 # Any other user configuration goes below
-scope:
-    temporal:
-        first_year: 2016
-        final_year: 2016

--- a/modules/demand_electricity/workflow/Snakefile
+++ b/modules/demand_electricity/workflow/Snakefile
@@ -22,6 +22,6 @@ if config["use_default_user_resources"]:
     rule all:
         message: "Generate all outputs for 'demand_electricity'."
         input:
-            expand("results/demand_electricity_{resolution}.csv", resolution="ehighways"),
-            expand("results/plot_timeseries_{resolution}.png", resolution="ehighways"),
-            expand("results/plot_map_{resolution}.png", resolution="ehighways")
+            expand("results/{resolution}/demand_electricity.csv", resolution="ehighways"),
+            expand("results/{resolution}/plot_timeseries.png", resolution="ehighways"),
+            expand("results/{resolution}/plot_map.png", resolution="ehighways")

--- a/modules/demand_electricity/workflow/Snakefile
+++ b/modules/demand_electricity/workflow/Snakefile
@@ -22,6 +22,6 @@ if config["use_default_user_resources"]:
     rule all:
         message: "Generate all outputs for 'demand_electricity'."
         input:
-            expand("results/{resolution}/demand_electricity.csv", resolution="ehighways"),
-            expand("results/{resolution}/plot_timeseries.png", resolution="ehighways"),
-            expand("results/{resolution}/plot_map.png", resolution="ehighways")
+            expand("results/{resolution}/{year}/demand_electricity.csv", resolution="ehighways", year=2016),
+            expand("results/{resolution}/{year}/plot_timeseries.png", resolution="ehighways", year=2016),
+            expand("results/{resolution}/{year}/plot_map.png", resolution="ehighways", year=2016)

--- a/modules/demand_electricity/workflow/envs/plot.yaml
+++ b/modules/demand_electricity/workflow/envs/plot.yaml
@@ -3,7 +3,7 @@
 # Once geo.yaml is updated, this can env can probably be removed
 name: plot
 channels:
-    - conda-forge
+  - conda-forge
 dependencies:
   - python=3.11
   - pandas=2.2.2

--- a/modules/demand_electricity/workflow/internal/internal_config.yaml
+++ b/modules/demand_electricity/workflow/internal/internal_config.yaml
@@ -6,10 +6,6 @@ resources:
 
 scaling_factors: # values are tuned for models with a few hours resolution and one year duration
     power: 0.00001 # from MW(h) to 100 GW(h)
-    area: 0.0001 # from km2 to 10,000 km2
-    monetary: 0.000000001 # from EUR to 1 billion EUR
-    transport: 0.01  # from Mio km to 100 Mio km
-    co2: 0.0001  # from t to 10 kt
 scope:
     spatial:
         countries:
@@ -52,9 +48,6 @@ scope:
             x_max: 37
             y_min: 30
             y_max: 75
-    temporal:
-        first-year: 2016
-        final-year: 2016
 quality_control:
   load:
       outlier-data-thresholds:

--- a/modules/demand_electricity/workflow/report/report.rst
+++ b/modules/demand_electricity/workflow/report/report.rst
@@ -1,1 +1,0 @@
-Report of 'demand_electricity'.

--- a/modules/demand_electricity/workflow/rules/demand.smk
+++ b/modules/demand_electricity/workflow/rules/demand.smk
@@ -22,7 +22,7 @@ rule electricity_load:
         national_load = rules.electricity_load_national.output[0]
     params:
         scaling_factor = internal["scaling_factors"]["power"]
-    output: "results/demand_electricity_{resolution}.csv"
+    output: "results/{resolution}/demand_electricity.csv"
     conda: "../envs/geo.yaml"
     script: "../scripts/load.py"
 
@@ -31,7 +31,7 @@ rule plot:
         demand_electricity=rules.electricity_load.output[0],
         shapes="resources/user/shapes_{resolution}.geojson"
     output:
-        timeseries="results/plot_timeseries_{resolution}.png",
-        maps="results/plot_map_{resolution}.png"
+        timeseries="results/{resolution}/plot_timeseries.png",
+        maps="results/{resolution}/plot_map.png"
     conda: "../envs/plot.yaml"
     script: "../scripts/plot.py"

--- a/modules/demand_electricity/workflow/rules/demand.smk
+++ b/modules/demand_electricity/workflow/rules/demand.smk
@@ -5,11 +5,11 @@ rule electricity_load_national:
     input:
         load = rules.download_raw_load.output[0]
     params:
-        first_year = config["scope"]["temporal"]["first_year"],
-        final_year = config["scope"]["temporal"]["final_year"],
         data_quality_config = internal["quality_control"]["load"],
         countries = internal["scope"]["spatial"]["countries"]
-    output: "results/electricity_demand_national.csv"
+    wildcard_constraints:
+        year = "|".join([str(i) for i in range(2005, 2020)])
+    output: "results/electricity_demand_national_{year}.csv"
     conda: "../envs/default.yaml"
     script: "../scripts/national_load.py"
 
@@ -19,19 +19,19 @@ rule electricity_load:
     input:
         units = "resources/user/shapes_{resolution}.geojson",
         demand_per_unit = rules.unzip_potentials.output.demand,
-        national_load = rules.electricity_load_national.output[0]
+        national_load = "results/electricity_demand_national_{year}.csv"
     params:
         scaling_factor = internal["scaling_factors"]["power"]
-    output: "results/{resolution}/demand_electricity.csv"
+    output: "results/{resolution}/{year}/demand_electricity.csv"
     conda: "../envs/geo.yaml"
     script: "../scripts/load.py"
 
 rule plot:
     input:
-        demand_electricity=rules.electricity_load.output[0],
+        demand_electricity="results/{resolution}/{year}/demand_electricity.csv",
         shapes="resources/user/shapes_{resolution}.geojson"
     output:
-        timeseries="results/{resolution}/plot_timeseries.png",
-        maps="results/{resolution}/plot_map.png"
+        timeseries="results/{resolution}/{year}/plot_timeseries.png",
+        maps="results/{resolution}/{year}/plot_map.png"
     conda: "../envs/plot.yaml"
     script: "../scripts/plot.py"

--- a/modules/demand_electricity/workflow/rules/downloads.smk
+++ b/modules/demand_electricity/workflow/rules/downloads.smk
@@ -32,4 +32,5 @@ rule unzip_potentials:
     output:
         demand = "resources/automatic/{resolution}/demand.csv",
     conda: "../envs/shell.yaml"
+    shadow: "minimal"
     shell: "unzip -p {input} '{wildcards.resolution}/demand.csv' > '{output.demand}'"

--- a/modules/demand_electricity/workflow/rules/downloads.smk
+++ b/modules/demand_electricity/workflow/rules/downloads.smk
@@ -13,7 +13,7 @@ if config["use_default_user_resources"]:
 rule download_raw_load:
     message: "Download raw load."
     params: url = internal["resources"]["load"]
-    output: protected("resources/raw_load_data.csv")
+    output: "resources/automatic/raw_load_data.csv"
     conda: "../envs/shell.yaml"
     localrule: True
     shell: "curl -sLo {output} '{params.url}'"
@@ -21,7 +21,7 @@ rule download_raw_load:
 rule download_potentials:
     message: "Download potential data."
     params: url = internal["resources"]["potentials"]
-    output: protected("resources/raw_potentials.zip")
+    output: temp("resources/automatic/raw_potentials.zip")
     conda: "../envs/shell.yaml"
     localrule: True
     shell: "curl -sSLo {output} '{params.url}'"
@@ -30,6 +30,6 @@ rule unzip_potentials:
     message: "Unzip potentials."
     input: rules.download_potentials.output[0]
     output:
-        demand = "resources/{resolution}/demand.csv",
+        demand = "resources/automatic/{resolution}/demand.csv",
     conda: "../envs/shell.yaml"
-    shell: "unzip {input} '{wildcards.resolution}/demand.csv' -d resources"
+    shell: "unzip -p {input} '{wildcards.resolution}/demand.csv' > '{output.demand}'"

--- a/modules/demand_electricity/workflow/schemas/config.schema.yaml
+++ b/modules/demand_electricity/workflow/schemas/config.schema.yaml
@@ -6,19 +6,3 @@ properties:
   use_default_user_resources:
     type: boolean
     description: "If True, the module will attempt to download default resource files instead of relying on custom user inputs."
-  scope:
-    type: object
-    additionalProperties: false
-    description: Scope defines the spatial and temporal boundaries of the analysis.
-    properties:
-      temporal:
-        type: object
-        additionalProperties: false
-        description: Temporal boundaries of the analysis.
-        properties:
-          first_year:
-            type: integer
-            description: First year of the analysis.
-          final_year:
-            type: integer
-            description: Final year of the analysis.

--- a/modules/demand_electricity/workflow/scripts/national_load.py
+++ b/modules/demand_electricity/workflow/scripts/national_load.py
@@ -24,22 +24,14 @@ import pycountry
 
 
 def national_load(
-    path_to_raw_load,
-    year,
-    data_quality_config,
-    path_to_output,
-    countries,
+    path_to_raw_load, year, data_quality_config, path_to_output, countries
 ):
     """Extracts national load time series for all countries in a specified year."""
-    load = clean_load_data(
-        path_to_raw_load, year, data_quality_config, countries
-    )
+    load = clean_load_data(path_to_raw_load, year, data_quality_config, countries)
     load.to_csv(path_to_output, header=True)
 
 
-def clean_load_data(
-    path_to_raw_load, year, data_quality_config, countries
-):
+def clean_load_data(path_to_raw_load, year, data_quality_config, countries):
     """Cleans load data.
 
     TODO: Extend docstring.

--- a/modules/demand_electricity/workflow/scripts/national_load.py
+++ b/modules/demand_electricity/workflow/scripts/national_load.py
@@ -46,10 +46,7 @@ def clean_load_data(path_to_raw_load, year, data_quality_config, countries):
     ).sort_index()
     return get_source_choice_per_country(
         filtered_load[
-            (
-                filtered_load.index.get_level_values("timesteps")
-                >= f"{year}-01-01 00:00"
-            )
+            (filtered_load.index.get_level_values("timesteps") >= f"{year}-01-01 00:00")
             & (
                 filtered_load.index.get_level_values("timesteps")
                 <= f"{year}-12-31 23:00"

--- a/modules/demand_electricity/workflow/scripts/national_load.py
+++ b/modules/demand_electricity/workflow/scripts/national_load.py
@@ -47,11 +47,11 @@ def clean_load_data(path_to_raw_load, year, data_quality_config, countries):
     return get_source_choice_per_country(
         filtered_load[
             (
-                filtered_load.index.get_level_values("utc_timestamp")
+                filtered_load.index.get_level_values("timesteps")
                 >= f"{year}-01-01 00:00"
             )
             & (
-                filtered_load.index.get_level_values("utc_timestamp")
+                filtered_load.index.get_level_values("timesteps")
                 <= f"{year}-12-31 23:00"
             )
         ],
@@ -66,6 +66,7 @@ def read_load_profiles(path_to_raw_load, entsoe_priority):
     load_by_attribute = (
         data[(data.variable == "load") & (data.attribute.isin(entsoe_priority))]
         .set_index(["utc_timestamp", "attribute", "region"])
+        .rename_axis(index={"utc_timestamp": "timesteps"})
         .loc[:, "data"]
         .unstack("region")
     )

--- a/modules/demand_electricity/workflow/scripts/national_load.py
+++ b/modules/demand_electricity/workflow/scripts/national_load.py
@@ -25,21 +25,20 @@ import pycountry
 
 def national_load(
     path_to_raw_load,
-    first_year,
-    final_year,
+    year,
     data_quality_config,
     path_to_output,
     countries,
 ):
     """Extracts national load time series for all countries in a specified year."""
     load = clean_load_data(
-        path_to_raw_load, first_year, final_year, data_quality_config, countries
+        path_to_raw_load, year, data_quality_config, countries
     )
     load.to_csv(path_to_output, header=True)
 
 
 def clean_load_data(
-    path_to_raw_load, first_year, final_year, data_quality_config, countries
+    path_to_raw_load, year, data_quality_config, countries
 ):
     """Cleans load data.
 
@@ -52,17 +51,16 @@ def clean_load_data(
     gap_filled_load = pd.concat(
         fill_gaps_per_source(filtered_load, year, data_quality_config, source)
         for source in data_sources
-        for year in range(first_year, final_year + 1)
     ).sort_index()
     return get_source_choice_per_country(
         filtered_load[
             (
                 filtered_load.index.get_level_values("utc_timestamp")
-                >= f"{first_year}-01-01 00:00"
+                >= f"{year}-01-01 00:00"
             )
             & (
                 filtered_load.index.get_level_values("utc_timestamp")
-                <= f"{final_year}-12-31 23:00"
+                <= f"{year}-12-31 23:00"
             )
         ],
         gap_filled_load,
@@ -322,8 +320,7 @@ def _select_load_by_source_priority(load, source_priority):
 if __name__ == "__main__":
     national_load(
         path_to_raw_load=snakemake.input.load,
-        first_year=snakemake.params.first_year,
-        final_year=snakemake.params.final_year,
+        year=int(snakemake.wildcards.year),
         data_quality_config=snakemake.params.data_quality_config,
         countries=snakemake.params.countries,
         path_to_output=snakemake.output[0],


### PR DESCRIPTION
Closes #54  #46

**demand**
- [x] README does not show the right outputs.
- [x] Citation and references are missing.
- [x] Needs to use `resources/automatic/` folder.
- [x] Moved resolution-specific outputs to their own folder to avoid confusion with `electricity_demand_national.csv`
- [x] removed `report/` (unused)
- [x] Avoided misleading outputs by adding a `{year}` wildcard were relevant.

